### PR TITLE
Extend debug mode for matrix operations with detailed output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ cmake \
     -DLIB_TESTS=ON \
     -DBUILD_LIB_CB_EMU=ON \
     -DBUILD_LIB_ACS_INT=ON \
+    # -DDEBUG_MODE=ON \    # Add -DDEBUG_MODE=ON to enable debug output of matrix operations (cpy_mtrx and mvm)
     ../../../cpp
 
 make -j `nproc`

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -34,6 +34,9 @@ add_subdirectory(extern/json EXCLUDE_FROM_ALL)
 # Test options
 option(LIB_TESTS "Build lib tests." OFF)
 
+# Debug mode for matrix operations
+option(DEBUG_MODE "Enable debug output for matrix operations" OFF)
+
 # Build lib options
 option(BUILD_LIB_CB_EMU "Build emulater/callback interface." OFF)
 option(BUILD_LIB_ACS_INT "Build int lib." OFF)
@@ -118,4 +121,9 @@ if(LIB_TESTS)
     message(STATUS "Enabling cpp tests.")
     enable_testing()
     add_subdirectory(test)
+endif()
+
+if(DEBUG_MODE)
+    add_definitions(-DDEBUG_MODE)
+    message(STATUS "Debug mode enabled - will print matrix operation details")
 endif()

--- a/cpp/src/interface_cb.cpp
+++ b/cpp/src/interface_cb.cpp
@@ -29,7 +29,26 @@ cpy_c_to_py_funcptr cpy_c_to_py = nullptr;
 extern "C" void set_cpy_python_cb(cpy_c_to_py_funcptr cb) { cpy_c_to_py = cb; }
 
 extern "C" int32_t exe_mvm(int32_t *res, int32_t *vec, int32_t *mat,
-                           int32_t m_matrix, int32_t n_matrix) {
+                           int32_t m_matrix, int32_t n_matrix,
+                           const char *l_name = "Unknown") {
+#ifdef DEBUG_MODE
+    std::cout << "Matrix-vector multiplication" << std::endl;
+    std::cout << "Layer: " << l_name << std::endl;
+// Find max and min values in the input vector
+#include <cstdint>
+    int32_t max_val = INT32_MIN;
+    int32_t min_val = INT32_MAX;
+    for (int i = 0; i < n_matrix; ++i) {
+        int32_t val = vec[i];
+        if (val > max_val)
+            max_val = val;
+        if (val < min_val)
+            min_val = val;
+    }
+    std::cout << "Input vector dimensions: " << n_matrix << std::endl;
+    std::cout << "Max value: " << max_val << ", Min value: " << min_val
+              << std::endl;
+#endif
     static int warning_done = 0;
     if (!mvm_c_to_py) {
         if (!warning_done) {
@@ -46,13 +65,47 @@ extern "C" int32_t exe_mvm(int32_t *res, int32_t *vec, int32_t *mat,
         return 0;
     }
     (*mvm_c_to_py)(res, vec, mat, m_matrix, n_matrix);
+#ifdef DEBUG_MODE
+// Find max and min values in the result vector
+#include <cstdint>
+    max_val = INT32_MIN;
+    min_val = INT32_MAX;
+    for (int i = 0; i < m_matrix; ++i) {
+        int32_t val = res[i];
+        if (val > max_val)
+            max_val = val;
+        if (val < min_val)
+            min_val = val;
+    }
+    std::cout << "Result vector dimensions: " << m_matrix << std::endl;
+    std::cout << "Max value: " << max_val << ", Min value: " << min_val
+              << std::endl;
+#endif
     return 0;
 }
 
 extern "C" int32_t cpy_mtrx(int32_t *mat, int32_t m_matrix, int32_t n_matrix,
-                            const char *l_name) {
+                            const char *l_name = "Unknown") {
 #ifdef DEBUG_MODE
+    std::cout << "Matrix copy" << std::endl;
     std::cout << "Layer: " << l_name << std::endl;
+// Find max and min values in the matrix
+#include <cstdint>
+    int32_t max_val = INT32_MIN;
+    int32_t min_val = INT32_MAX;
+    for (int i = 0; i < m_matrix; ++i) {
+        for (int j = 0; j < n_matrix; ++j) {
+            int32_t val = mat[i * n_matrix + j];
+            if (val > max_val)
+                max_val = val;
+            if (val < min_val)
+                min_val = val;
+        }
+    }
+    std::cout << "Matrix dimensions: " << m_matrix << "x" << n_matrix
+              << std::endl;
+    std::cout << "Max value: " << max_val << ", Min value: " << min_val
+              << std::endl;
 #endif
     static int warning_done = 0;
     if (!cpy_c_to_py) {

--- a/cpp/src/interface_xbar.cpp
+++ b/cpp/src/interface_xbar.cpp
@@ -55,7 +55,26 @@ extern "C" EXPORT_API void set_config(const char *cfg_file) {
 }
 
 extern "C" EXPORT_API int32_t exe_mvm(int32_t *res, int32_t *vec, int32_t *mat,
-                                      int32_t m_matrix, int32_t n_matrix) {
+                                      int32_t m_matrix, int32_t n_matrix,
+                                      const char *l_name = "Unknown") {
+#ifdef DEBUG_MODE
+    std::cout << "Matrix-vector multiplication" << std::endl;
+    std::cout << "Layer: " << l_name << std::endl;
+// Find max and min values in the input vector
+#include <cstdint>
+    int32_t max_val = INT32_MIN;
+    int32_t min_val = INT32_MAX;
+    for (int i = 0; i < n_matrix; ++i) {
+        int32_t val = vec[i];
+        if (val > max_val)
+            max_val = val;
+        if (val < min_val)
+            min_val = val;
+    }
+    std::cout << "Input vector dimensions: " << n_matrix << std::endl;
+    std::cout << "Max value: " << max_val << ", Min value: " << min_val
+              << std::endl;
+#endif
     if (xbar == nullptr) {
         std::cerr << "Error: Crossbar is not initialized. Please call "
                      "set_config() first."
@@ -68,12 +87,49 @@ extern "C" EXPORT_API int32_t exe_mvm(int32_t *res, int32_t *vec, int32_t *mat,
         return -1;
     }
     xbar->mvm(res, vec, mat, m_matrix, n_matrix);
+#ifdef DEBUG_MODE
+// Find max and min values in the result vector
+#include <cstdint>
+    max_val = INT32_MIN;
+    min_val = INT32_MAX;
+    for (int i = 0; i < m_matrix; ++i) {
+        int32_t val = res[i];
+        if (val > max_val)
+            max_val = val;
+        if (val < min_val)
+            min_val = val;
+    }
+    std::cout << "Result vector dimensions: " << m_matrix << std::endl;
+    std::cout << "Max value: " << max_val << ", Min value: " << min_val
+              << std::endl;
+#endif
     return 0;
 }
 
 extern "C" EXPORT_API int32_t cpy_mtrx(int32_t *mat, int32_t m_matrix,
                                        int32_t n_matrix,
                                        const char *l_name = "Unkown") {
+#ifdef DEBUG_MODE
+    std::cout << "Matrix copy" << std::endl;
+    std::cout << "Layer: " << l_name << std::endl;
+// Find max and min values in the matrix
+#include <cstdint>
+    int32_t max_val = INT32_MIN;
+    int32_t min_val = INT32_MAX;
+    for (int i = 0; i < m_matrix; ++i) {
+        for (int j = 0; j < n_matrix; ++j) {
+            int32_t val = mat[i * n_matrix + j];
+            if (val > max_val)
+                max_val = val;
+            if (val < min_val)
+                min_val = val;
+        }
+    }
+    std::cout << "Matrix dimensions: " << m_matrix << "x" << n_matrix
+              << std::endl;
+    std::cout << "Max value: " << max_val << ", Min value: " << min_val
+              << std::endl;
+#endif
     if (xbar == nullptr) {
         std::cerr << "Error: Crossbar is not initialized. Please call "
                      "set_config() first."


### PR DESCRIPTION
Adds DEBUG_MODE CMake option that enables detailed logging of matrix operations. When enabled, the system prints information about matrix dimensions, min/max values, and layer names during matrix-vector multiplications and matrix copy operations.

To enable: Add -DDEBUG_MODE=ON to your CMake configuration.