### PR TITLE
Refactor Config update methods to simplify JSON configuration handling

### DIFF
--- a/cpp/inc/helper/config.h
+++ b/cpp/inc/helper/config.h
@@ -36,15 +36,12 @@ class Config {
     bool is_int_mapping(const MappingMode &mode);
     bool is_bnn_mapping(const MappingMode &mode);
     bool is_tnn_mapping(const MappingMode &mode);
-    bool update_from_json(const char *json_string,
-                          bool *recreate_xbar = nullptr,
-                          const std::vector<std::string> &recreation_keys = {
-                              "M", "N", "SPLIT", "digital_only", "HRS", "LRS",
-                              "adc_type", "alpha", "resolution", "m_mode",
-                              "HRS_NOISE", "LRS_NOISE", "read_disturb",
-                              "V_read", "t_read", "read_disturb_update_freq"});
-    template <typename T>
-    bool update_cfg(const std::string &key, const T &value);
+    bool update_cfg(const char *json_string, bool *recreate_xbar = nullptr,
+                    const std::vector<std::string> &recreation_keys = {
+                        "M", "N", "SPLIT", "digital_only", "HRS", "LRS",
+                        "adc_type", "alpha", "resolution", "m_mode",
+                        "HRS_NOISE", "LRS_NOISE", "read_disturb", "V_read",
+                        "t_read", "read_disturb_update_freq"});
 
     // Matrix dimensions MxN
     uint32_t M;

--- a/cpp/src/interface_xbar.cpp
+++ b/cpp/src/interface_xbar.cpp
@@ -68,7 +68,7 @@ extern "C" EXPORT_API void update_config(const char *json_config) {
 
     // Let Config class handle the JSON parsing and updates
     bool config_updated =
-        nq::Config::get_cfg().update_from_json(json_config, &recreate_xbar);
+        nq::Config::get_cfg().update_cfg(json_config, &recreate_xbar);
 
     // Only recreate crossbar if necessary keys were updated
     if (config_updated && recreate_xbar) {


### PR DESCRIPTION
This PR simplifies and improves the configuration update process by:

- Consolidating configuration update methods into `update_cfg()` function
- Removing the templated `update_cfg<T>()` function that is no longer used
- Simplifying the JSON parsing and comparison logic
- Applying changes to `Config` only once per update JSON
- Adding error handling for JSON parse failures