### PR TITLE
[Bugfix] Step width in differential mappings can exceed LRS current

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev*
+      - dev/**
   pull_request:
     branches:
       - main

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev*
+      - dev/**
   pull_request:
     branches:
       - main

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev*
+      - dev/**
   pull_request:
     branches:
       - main

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev*
+      - dev/**
   pull_request:
     branches:
       - main

--- a/cpp/src/mapping/mapper.cpp
+++ b/cpp/src/mapping/mapper.cpp
@@ -66,14 +66,8 @@ Mapper::Mapper(bool is_diff_weight_mapping) :
         }
         num_segments_ = CFG.SPLIT.size();
 
-        if (is_diff_weight_mapping_) {
-            for (size_t s = 0; s < num_segments_; ++s) {
-                i_step_size_[s] = i_mm_ / ((1 << (CFG.SPLIT[s] - 1)));
-            }
-        } else {
-            for (size_t s = 0; s < num_segments_; ++s) {
-                i_step_size_[s] = i_mm_ / ((1 << CFG.SPLIT[s]) - 1);
-            }
+        for (size_t s = 0; s < num_segments_; ++s) {
+            i_step_size_[s] = i_mm_ / ((1 << CFG.SPLIT[s]) - 1);
         }
     }
 }

--- a/cpp/test/lib/adc_tests.cpp
+++ b/cpp/test/lib/adc_tests.cpp
@@ -4,7 +4,7 @@
 
 #include "inc/test_helper.h"
 
-TEST(ADCTests, SymADCTest) {
+TEST(ADCTests, SymADCTest_I_DIFF) {
     const int32_t m_matrix = 3;
     const int32_t n_matrix = 5;
     int32_t mat[m_matrix * n_matrix] = {-128, -128, -128, -128, -128,
@@ -21,7 +21,27 @@ TEST(ADCTests, SymADCTest) {
 
     status = exe_mvm(res, vec, mat, m_matrix, n_matrix);
     ASSERT_EQ(status, 0) << "Matrix-vector multiplication failed.";
-    ASSERT_THAT(res, ::testing::ElementsAre(640, -635, -40));
+    ASSERT_THAT(res, ::testing::ElementsAre(640, -635, -42));
+}
+
+TEST(ADCTests, SymADCTest_I_OFFS) {
+    const int32_t m_matrix = 3;
+    const int32_t n_matrix = 5;
+    int32_t mat[m_matrix * n_matrix] = {-128, -128, -128, -128, -128,
+                                        127,  127,  127,  127,  127,
+                                        -12,  88,   65,   0,    -99};
+    int32_t vec[n_matrix] = {1, 1, 1, 1, 1};
+    int32_t res[m_matrix] = {0, 0, 0};
+
+    std::string cfg = get_cfg_file("analog/SYM_ADC_2.json");
+    set_config(cfg.c_str());
+
+    int32_t status = cpy_mtrx(mat, m_matrix, n_matrix);
+    ASSERT_EQ(status, 0) << "Matrix write operation failed.";
+
+    status = exe_mvm(res, vec, mat, m_matrix, n_matrix);
+    ASSERT_EQ(status, 0) << "Matrix-vector multiplication failed.";
+    ASSERT_THAT(res, ::testing::ElementsAre(-640, 635, 42));
 }
 
 TEST(ADCTests, PosADCTest) {
@@ -56,7 +76,7 @@ TEST(ADCTests, SymADCCalibrationTest) {
     update_config(R"(
       {
          "adc_calib_mode": "CALIB",
-         "adc_calib_dict": {"test_layer": [-30.0, 30.0]}
+         "adc_calib_dict": {"test_layer": [-1.0, 1.0]}
       }
     )");
 

--- a/cpp/test/lib/configs/analog/SYM_ADC_1.json
+++ b/cpp/test/lib/configs/analog/SYM_ADC_1.json
@@ -10,7 +10,7 @@
     "HRS": 5.0,
     "LRS": 30.0,
     "adc_type": "SYM_RANGE_ADC",
-    "resolution": 8,
+    "resolution": 12,
     "m_mode": "I_DIFF_W_DIFF_1XB",
     "HRS_NOISE": 0.0,
     "LRS_NOISE": 0.0,

--- a/cpp/test/lib/configs/analog/SYM_ADC_2.json
+++ b/cpp/test/lib/configs/analog/SYM_ADC_2.json
@@ -10,7 +10,7 @@
     "HRS": 5.0,
     "LRS": 30.0,
     "adc_type": "SYM_RANGE_ADC",
-    "resolution": 8,
+    "resolution": 13,
     "m_mode": "I_OFFS_W_DIFF",
     "HRS_NOISE": 0.0,
     "LRS_NOISE": 0.0,

--- a/int-bindings/test/adc_test.py
+++ b/int-bindings/test/adc_test.py
@@ -11,6 +11,7 @@ import acs_int
 import json
 import os
 import sys
+import tempfile
 
 repo_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../'))
 sys.path.append(repo_path)
@@ -43,17 +44,21 @@ class TestADC(unittest.TestCase):
         for b in resolution:
             cfg["resolution"] = b
 
-            with open(cfg_file, "w") as file:
-                json.dump(cfg, file, indent=4)
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp_cfg:
+                json.dump(cfg, tmp_cfg, indent=4)
+                tmp_cfg_path = tmp_cfg.name
 
-            acs_int.set_config(os.path.abspath(cfg_file))
-            acs_int.cpy(mat, m_matrix, n_matrix)
+            try:
+                acs_int.set_config(os.path.abspath(tmp_cfg_path))
+                acs_int.cpy(mat, m_matrix, n_matrix)
 
-            res = np.zeros(m_matrix, dtype=np.int32)
-            acs_int.mvm(res, vec, mat, m_matrix, n_matrix)
+                res = np.zeros(m_matrix, dtype=np.int32)
+                acs_int.mvm(res, vec, mat, m_matrix, n_matrix)
+            finally:
+                os.remove(tmp_cfg_path)
 
-            delta = adc_range / ((2**b) - 1)
-            step_size = (cfg["LRS"] - cfg["HRS"]) / (2**(cfg["W_BIT"] - 1))
+            delta = adc_range / ((2**b) - 2)
+            step_size = (cfg["LRS"] - cfg["HRS"]) / ((2**cfg["W_BIT"]) - 1)
             max_error = (delta / 2) / step_size
 
             for c_idx, c in enumerate(correct_result):
@@ -84,17 +89,21 @@ class TestADC(unittest.TestCase):
         for b in resolution:
             cfg["resolution"] = b
 
-            with open(cfg_file, "w") as file:
-                json.dump(cfg, file, indent=4)
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp_cfg:
+                json.dump(cfg, tmp_cfg, indent=4)
+                tmp_cfg_path = tmp_cfg.name
 
-            acs_int.set_config(os.path.abspath(cfg_file))
-            acs_int.cpy(mat, m_matrix, n_matrix)
+            try:
+                acs_int.set_config(os.path.abspath(tmp_cfg_path))
+                acs_int.cpy(mat, m_matrix, n_matrix)
 
-            res = np.zeros(m_matrix, dtype=np.int32)
-            acs_int.mvm(res, vec, mat, m_matrix, n_matrix)
+                res = np.zeros(m_matrix, dtype=np.int32)
+                acs_int.mvm(res, vec, mat, m_matrix, n_matrix)
+            finally:
+                os.remove(tmp_cfg_path)
 
-            delta = adc_range / ((2**b) - 1)
-            step_size = (cfg["LRS"] - cfg["HRS"]) / (2**(cfg["W_BIT"] - 1))
+            delta = adc_range / ((2**b) - 2)
+            step_size = (cfg["LRS"] - cfg["HRS"]) / ((2**cfg["W_BIT"]) - 1)
             max_error = (delta / 2) / step_size
 
             for c_idx, c in enumerate(correct_result):
@@ -125,17 +134,21 @@ class TestADC(unittest.TestCase):
         for b in resolution:
             cfg["resolution"] = b
 
-            with open(cfg_file, "w") as file:
-                json.dump(cfg, file, indent=4)
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp_cfg:
+                json.dump(cfg, tmp_cfg, indent=4)
+                tmp_cfg_path = tmp_cfg.name
 
-            acs_int.set_config(os.path.abspath(cfg_file))
-            acs_int.cpy(mat, m_matrix, n_matrix)
+            try:
+                acs_int.set_config(os.path.abspath(tmp_cfg_path))
+                acs_int.cpy(mat, m_matrix, n_matrix)
 
-            res = np.zeros(m_matrix, dtype=np.int32)
-            acs_int.mvm(res, vec, mat, m_matrix, n_matrix)
+                res = np.zeros(m_matrix, dtype=np.int32)
+                acs_int.mvm(res, vec, mat, m_matrix, n_matrix)
+            finally:
+                os.remove(tmp_cfg_path)
 
-            delta = adc_range / ((2**b) - 1)
-            step_size = (cfg["LRS"] - cfg["HRS"]) / (2**(cfg["W_BIT"] - 1))
+            delta = adc_range / ((2**b) - 2)
+            step_size = (cfg["LRS"] - cfg["HRS"]) / ((2**cfg["W_BIT"]) - 1)
             max_error = (delta / 2) / step_size
 
             for c_idx, c in enumerate(correct_result):
@@ -166,17 +179,21 @@ class TestADC(unittest.TestCase):
         for b in resolution:
             cfg["resolution"] = b
 
-            with open(cfg_file, "w") as file:
-                json.dump(cfg, file, indent=4)
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp_cfg:
+                json.dump(cfg, tmp_cfg, indent=4)
+                tmp_cfg_path = tmp_cfg.name
 
-            acs_int.set_config(os.path.abspath(cfg_file))
-            acs_int.cpy(mat, m_matrix, n_matrix)
+            try:
+                acs_int.set_config(os.path.abspath(tmp_cfg_path))
+                acs_int.cpy(mat, m_matrix, n_matrix)
 
-            res = np.zeros(m_matrix, dtype=np.int32)
-            acs_int.mvm(res, vec, mat, m_matrix, n_matrix)
+                res = np.zeros(m_matrix, dtype=np.int32)
+                acs_int.mvm(res, vec, mat, m_matrix, n_matrix)
+            finally:
+                os.remove(tmp_cfg_path)
 
-            delta = adc_range / ((2**b) - 1)
-            step_size = (cfg["LRS"] - cfg["HRS"]) / (2**(cfg["W_BIT"] - 1))
+            delta = adc_range / ((2**b) - 2)
+            step_size = (cfg["LRS"] - cfg["HRS"]) / ((2**cfg["W_BIT"]) - 1)
             max_error = (delta / 2) / step_size
 
             for c_idx, c in enumerate(correct_result):
@@ -207,14 +224,18 @@ class TestADC(unittest.TestCase):
         for b in resolution:
             cfg["resolution"] = b
 
-            with open(cfg_file, "w") as file:
-                json.dump(cfg, file, indent=4)
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp_cfg:
+                json.dump(cfg, tmp_cfg, indent=4)
+                tmp_cfg_path = tmp_cfg.name
 
-            acs_int.set_config(os.path.abspath(cfg_file))
-            acs_int.cpy(mat, m_matrix, n_matrix)
+            try:
+                acs_int.set_config(os.path.abspath(tmp_cfg_path))
+                acs_int.cpy(mat, m_matrix, n_matrix)
 
-            res = np.zeros(m_matrix, dtype=np.int32)
-            acs_int.mvm(res, vec, mat, m_matrix, n_matrix)
+                res = np.zeros(m_matrix, dtype=np.int32)
+                acs_int.mvm(res, vec, mat, m_matrix, n_matrix)
+            finally:
+                os.remove(tmp_cfg_path)
 
             delta = adc_range / ((2**b) - 1)
             step_size = (cfg["LRS"] - cfg["HRS"]) / (2**(cfg["W_BIT"]) - 1)


### PR DESCRIPTION
* Fixed the `step_size_` calculation in `mapper.cpp` for the differential mode: Previously, it was possible to get a current value that is bigger than the LRS current, which is undesirable.
* All other changes are essentially adjustments to the tests.

Minor changes:
* `json` config files should not be overwritten; use temp paths instead
* Trigger action when branch begins with `dev/...`