### PR TITLE
Fix not being able to build with DEBUG_MODE=ON in cmake options

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,6 +47,7 @@ jobs:
           cd build
           cmake \
             -DCMAKE_BUILD_TYPE=${{matrix.BUILD_TYPE}} \
+            -DDEBUG_MODE=$([[ "${{matrix.BUILD_TYPE}}" == "Debug" ]] && echo "ON" || echo "OFF") \
             -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install \
             -DPY_INSTALL_PATH=${{github.workspace}}/.venv/lib/python3.8/site-packages \
             -DLIB_TESTS=ON \

--- a/cpp/src/interface_cb.cpp
+++ b/cpp/src/interface_cb.cpp
@@ -8,6 +8,10 @@
 #include "stdio.h"
 #include <iostream>
 
+#ifdef DEBUG_MODE
+#include <cstdint>
+#endif
+
 // Typedef for the function pointer for the C - Python conversion
 typedef int32_t (*mvm_c_to_py_funcptr)(int32_t *res, int32_t *vec, int32_t *mat,
                                        int32_t m_matrix, int32_t n_matrix,
@@ -71,8 +75,7 @@ extern "C" int32_t exe_mvm(int32_t *res, int32_t *vec, int32_t *mat,
 #ifdef DEBUG_MODE
     std::cout << "Matrix-vector multiplication" << std::endl;
     std::cout << "Layer: " << l_name << std::endl;
-// Find max and min values in the input vector
-#include <cstdint>
+    // Find max and min values in the input vector
     int32_t max_val = INT32_MIN;
     int32_t min_val = INT32_MAX;
     for (int i = 0; i < n_matrix; ++i) {
@@ -103,8 +106,7 @@ extern "C" int32_t exe_mvm(int32_t *res, int32_t *vec, int32_t *mat,
     }
     (*mvm_c_to_py)(res, vec, mat, m_matrix, n_matrix, l_name);
 #ifdef DEBUG_MODE
-// Find max and min values in the result vector
-#include <cstdint>
+    // Find max and min values in the result vector
     max_val = INT32_MIN;
     min_val = INT32_MAX;
     for (int i = 0; i < m_matrix; ++i) {
@@ -126,8 +128,7 @@ extern "C" int32_t cpy_mtrx(int32_t *mat, int32_t m_matrix, int32_t n_matrix,
 #ifdef DEBUG_MODE
     std::cout << "Matrix copy" << std::endl;
     std::cout << "Layer: " << l_name << std::endl;
-// Find max and min values in the matrix
-#include <cstdint>
+    // Find max and min values in the matrix
     int32_t max_val = INT32_MIN;
     int32_t min_val = INT32_MAX;
     for (int i = 0; i < m_matrix; ++i) {

--- a/cpp/src/interface_xbar.cpp
+++ b/cpp/src/interface_xbar.cpp
@@ -17,6 +17,10 @@
 #include "helper/config.h"
 #include "xbar/crossbar.h"
 
+#ifdef DEBUG_MODE
+#include <cstdint>
+#endif
+
 #ifndef EXPORT_API
 #define EXPORT_API __attribute__((visibility("default")))
 #endif
@@ -106,8 +110,7 @@ extern "C" EXPORT_API int32_t exe_mvm(int32_t *res, int32_t *vec, int32_t *mat,
 #ifdef DEBUG_MODE
     std::cout << "Matrix-vector multiplication" << std::endl;
     std::cout << "Layer: " << l_name << std::endl;
-// Find max and min values in the input vector
-#include <cstdint>
+    // Find max and min values in the input vector
     int32_t max_val = INT32_MIN;
     int32_t min_val = INT32_MAX;
     for (int i = 0; i < n_matrix; ++i) {
@@ -134,8 +137,7 @@ extern "C" EXPORT_API int32_t exe_mvm(int32_t *res, int32_t *vec, int32_t *mat,
     }
     xbar->mvm(res, vec, mat, m_matrix, n_matrix, l_name);
 #ifdef DEBUG_MODE
-// Find max and min values in the result vector
-#include <cstdint>
+    // Find max and min values in the result vector
     max_val = INT32_MIN;
     min_val = INT32_MAX;
     for (int i = 0; i < m_matrix; ++i) {
@@ -158,8 +160,7 @@ extern "C" EXPORT_API int32_t cpy_mtrx(int32_t *mat, int32_t m_matrix,
 #ifdef DEBUG_MODE
     std::cout << "Matrix copy" << std::endl;
     std::cout << "Layer: " << l_name << std::endl;
-// Find max and min values in the matrix
-#include <cstdint>
+    // Find max and min values in the matrix
     int32_t max_val = INT32_MIN;
     int32_t min_val = INT32_MAX;
     for (int i = 0; i < m_matrix; ++i) {


### PR DESCRIPTION
Building the library with the DEBUG_MODE option set to ON would result in an error while building with make:
```bash
In file included from /workspaces/analog-cim-sim/cpp/src/interface_cb.cpp:75:
/usr/include/c++/13/cstdint: In function 'int32_t exe_mvm(int32_t*, int32_t*, int32_t*, int32_t, int32_t, const char*)':
/usr/include/c++/13/cstdint:48:1: error: 'namespace' definition is not allowed here
   48 | namespace std
      | ^~~~~~~~~
make[2]: *** [CMakeFiles/acs_cb_emu.dir/build.make:79: CMakeFiles/acs_cb_emu.dir/src/interface_cb.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:217: CMakeFiles/acs_cb_emu.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```
The solution to this is to move the `cstdint` include to the top of the source files `interface_xbar.cpp` and `interface_cb.cpp`.
Additionally I've added the Debug mode option to the CI pipeline.