### PR TITLE
Added new shared library target only using the c/cpp interface

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+# Use Ubuntu 22.04 as the base image
+FROM ubuntu:22.04
+
+# Install system dependencies including CMake >= 3.15, Python3 development tools, and TBB
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends \
+    git \
+    ssh \
+    g++ \
+    gdb \
+    cmake \
+    python3 \
+    python3-dev \
+    libtbb-dev \
+    lcov \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the default command to bash
+SHELL ["/bin/bash", "-c"]

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+set -euo pipefail
+
+# Create the virtual environment if it does not exist
+if [ ! -d ".venv" ]; then
+    python3 -m venv .venv
+fi
+
+# Activate .venv environment
+source .venv/bin/activate
+
+# Install requirements
+pip install --upgrade pip
+pip install -r requirements.txt

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -53,6 +53,7 @@ jobs:
             -DLIB_TESTS=ON \
             -DBUILD_LIB_CB_EMU=ON \
             -DBUILD_LIB_ACS_INT=ON \
+            -DBUILD_LIB_ACS_CPP=ON \
             ../cpp
 
       - name: Build libs and tests

--- a/README.md
+++ b/README.md
@@ -22,57 +22,35 @@ This simulator is used by [CIM-E](https://github.com/rpelke/CIM-E), a design spa
 
 ## Build instructions
 
-### Requirements
-To build the project, you will require:
-- `cmake` >= 3.15
-- `python3` (*dev version* for pybind11)
-- oneAPI Threading Building Blocks (`oneTBB`). On Debian-based distributions, `sudo apt install libtbb-dev`. For more details see [here](https://uxlfoundation.github.io/oneTBB/index.html).
-
-If you are using the devcontainer, the requirements are already installed.
-
-### Building in the devcontainer
 Clone the repository including submodules:
 ```bash
 git clone --recursive git@github.com:rpelke/analog-cim-sim.git
 ```
+
+### Building in the devcontainer
 Reopen the folder in the devcontainer, the devcontainer.json will automatically build the container.
 
-Build and install the project (replace the placeholders):
+Run the build script provided in `scripts/build_acs.sh`:
 ```bash
-export PY_PACKAGE_DIR=<path to 'site-packages'> # can be found in .venv/lib/<python-version>
-
-mkdir -p build/release/build && cd build/release/build
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DPY_INSTALL_PATH=${PY_PACKAGE_DIR}/site-packages \
-    -DCMAKE_PREFIX_PATH=${PY_PACKAGE_DIR}/pybind11/share/cmake/pybind11 \
-    -DCMAKE_INSTALL_PREFIX=../ \
-    -DLIB_TESTS=ON \
-    -DBUILD_LIB_CB_EMU=ON \
-    -DBUILD_LIB_ACS_INT=ON \
-    ../../../cpp
-
-make -j `nproc`
-make install
+./scripts/build_acs.sh
 ```
 
 ### Native Building
-Clone the repository including submodules:
-```bash
-git clone --recursive git@github.com:rpelke/analog-cim-sim.git
-```
+Install the requirements listed under [Requirements](#Requirements)
 
-Create a virtual environment:
+If you are not using the devcontainer, create a virtual environment:
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
 pip3 install -r requirements.txt
 ```
-
-Build and install the project (replace the placeholders):
+Run the build script provided in `scripts/build_acs.sh`:
+```bash
+./scripts/build_acs.sh
+```
+**Or** build and install the project without the script (replace the placeholders):
 ```bash
 export PY_PACKAGE_DIR=<path to 'site-packages'> # can be found in .venv/lib/<python-version>
-
 
 mkdir -p build/release/build && cd build/release/build
 cmake \
@@ -89,7 +67,15 @@ cmake \
 make -j `nproc`
 make install
 ```
-This will build all available targets in debug mode with support for unittests and coverage
+This will build all available targets in release mode with support for unittests.
+
+### Requirements
+To build the project, you will require:
+- `cmake` >= 3.15
+- `python3` (*dev version* for pybind11)
+- oneAPI Threading Building Blocks (`oneTBB`). On Debian-based distributions, `sudo apt install libtbb-dev`. For more details see [here](https://uxlfoundation.github.io/oneTBB/index.html).
+
+If you are using the devcontainer, the requirements are already installed.
 
 ### Available building targets
 
@@ -107,7 +93,7 @@ cmake -DDEBUG_MODE=ON ...
 
 Build the project with support for coverage:
 ```bash
-cmake -DLIB_TESTS=ON -DCOVERAGE=ON ...
+cmake -DCMAKE_BUILD_TYPE=Debug -DLIB_TESTS=ON -DCOVERAGE=ON ...
 ```
 
 Use C++17 `filesystem` features for the [unittests](cpp/test/lib/inc/test_helper.h) with old gcc versions (<9.1):

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Build and install the project (replace the placeholders):
 ```bash
 export PY_PACKAGE_DIR=<path to 'site-packages'> # can be found in .venv/lib/<python-version>
 
+
 mkdir -p build/release/build && cd build/release/build
 cmake \
     -DCMAKE_BUILD_TYPE=Release \
@@ -82,16 +83,31 @@ cmake \
     -DLIB_TESTS=ON \
     -DBUILD_LIB_CB_EMU=ON \
     -DBUILD_LIB_ACS_INT=ON \
+    -DBUILD_LIB_ACS_CPP=ON \
     ../../../cpp
 
 make -j `nproc`
 make install
 ```
+This will build all available targets in debug mode with support for unittests and coverage
+
+### Available building targets
+
+| Target Name | Description | Enabled By | Installed To |
+|-------------|-------------|------------|--------------|
+| `acs_cb_emu` | Emulator/callback interface library | `BUILD_LIB_CB_EMU=ON` | `lib/` |
+| `acs_int` | Python binding module for the C++ library | `BUILD_LIB_ACS_INT=ON` | `${PY_INSTALL_PATH}` |
+| `acs_cpp` | Core C++ library, no interface | `BUILD_LIB_ACS_CPP=ON` | `lib/` (library) + `include/` (headers) |
 
 ### Some useful cmake options
 Build project with additional debug output:
 ```bash
 cmake -DDEBUG_MODE=ON ...
+```
+
+Build the project with support for coverage:
+```bash
+cmake -DLIB_TESTS=ON -DCOVERAGE=ON ...
 ```
 
 Use C++17 `filesystem` features for the [unittests](cpp/test/lib/inc/test_helper.h) with old gcc versions (<9.1):
@@ -109,3 +125,12 @@ To detect segmentation faults in the C++ part, you can also run:
 ```bash
 gdb --batch --ex="run" --ex="bt" --ex="quit" --args python3 -m unittest discover -s int-bindings/test -p '*_test.py'
 ```
+To manually test the coverage (library was built with -DCOVERAGE=ON set):
+```bash
+cd build/debug/build
+ctest -C . --output-on-failure
+lcov --capture --directory . --output-file coverage_int.info --include '*cpp*' --exclude '*extern*'
+genhtml coverage_int.info --output-directory coverage_int_html
+```
+The line and function coverage should be displayed at the end of the `genhtml` command.
+

--- a/README.md
+++ b/README.md
@@ -28,7 +28,35 @@ To build the project, you will require:
 - `python3` (*dev version* for pybind11)
 - oneAPI Threading Building Blocks (`oneTBB`). On Debian-based distributions, `sudo apt install libtbb-dev`. For more details see [here](https://uxlfoundation.github.io/oneTBB/index.html).
 
-### Building
+If you are using the devcontainer, the requirements are already installed.
+
+### Building in the devcontainer
+Clone the repository including submodules:
+```bash
+git clone --recursive git@github.com:rpelke/analog-cim-sim.git
+```
+Reopen the folder in the devcontainer, the devcontainer.json will automatically build the container.
+
+Build and install the project (replace the placeholders):
+```bash
+export PY_PACKAGE_DIR=<path to 'site-packages'> # can be found in .venv/lib/<python-version>
+
+mkdir -p build/release/build && cd build/release/build
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DPY_INSTALL_PATH=${PY_PACKAGE_DIR}/site-packages \
+    -DCMAKE_PREFIX_PATH=${PY_PACKAGE_DIR}/pybind11/share/cmake/pybind11 \
+    -DCMAKE_INSTALL_PREFIX=../ \
+    -DLIB_TESTS=ON \
+    -DBUILD_LIB_CB_EMU=ON \
+    -DBUILD_LIB_ACS_INT=ON \
+    ../../../cpp
+
+make -j `nproc`
+make install
+```
+
+### Native Building
 Clone the repository including submodules:
 ```bash
 git clone --recursive git@github.com:rpelke/analog-cim-sim.git

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,11 +14,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(COVERAGE "Enable code coverage." OFF)
 message(STATUS "Coverage: ${COVERAGE}")
 
-# Install path for python package
-if(NOT DEFINED PY_INSTALL_PATH)
-    message(FATAL_ERROR "PY_INSTALL_PATH is not set! Please define it with -DPY_INSTALL_PATH=<...>")
-endif()
-
 # Use gcc for coverage
 if (COVERAGE)
     set(CMAKE_C_COMPILER gcc)
@@ -26,6 +21,9 @@ if (COVERAGE)
 endif()
 
 project(analog-cim-sim)
+
+# Include for standardized install directories
+include(GNUInstallDirs)
 
 # Include json
 set(JSON_BuildTests OFF CACHE INTERNAL "")
@@ -40,6 +38,7 @@ option(DEBUG_MODE "Enable debug output for matrix operations" OFF)
 # Build lib options
 option(BUILD_LIB_CB_EMU "Build emulater/callback interface." OFF)
 option(BUILD_LIB_ACS_INT "Build int lib." OFF)
+option(BUILD_LIB_ACS_CPP "Build cpp lib." OFF)
 
 if (COVERAGE)
     if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -47,6 +46,32 @@ if (COVERAGE)
     endif()
 endif()
 
+# Set sources shared by acs_int and acs_cpp
+set(SOURCES_SHARED
+    src/helper/config.cpp
+    src/helper/histogram.cpp
+    src/mapping/mapper.cpp
+    src/mapping/int_mapper/int_i.cpp
+    src/mapping/int_mapper/int_ii.cpp
+    src/mapping/int_mapper/int_iii.cpp
+    src/mapping/int_mapper/int_iv.cpp
+    src/mapping/int_mapper/int_v.cpp
+    src/mapping/bnn_mapper/bnn_i.cpp
+    src/mapping/bnn_mapper/bnn_ii.cpp
+    src/mapping/bnn_mapper/bnn_iii.cpp
+    src/mapping/bnn_mapper/bnn_iv.cpp
+    src/mapping/bnn_mapper/bnn_v.cpp
+    src/mapping/bnn_mapper/bnn_vi.cpp
+    src/mapping/tnn_mapper/tnn_i.cpp
+    src/mapping/tnn_mapper/tnn_ii.cpp
+    src/mapping/tnn_mapper/tnn_iii.cpp
+    src/mapping/tnn_mapper/tnn_iv.cpp
+    src/mapping/tnn_mapper/tnn_v.cpp
+    src/xbar/crossbar.cpp
+    src/xbar/read_disturb.cpp
+    src/xbar/parasitics.cpp
+    src/xbar/adc.cpp
+)
 ### Build emulater/callback interface ###
 if(BUILD_LIB_CB_EMU)
     message(STATUS "Build emulater/callback interface.")
@@ -67,6 +92,10 @@ endif()
 ### Build Int library ###
 if(BUILD_LIB_ACS_INT)
     message(STATUS "Build LIB_ACS_INT.")
+    # Install path for python package
+    if(NOT DEFINED PY_INSTALL_PATH)
+        message(FATAL_ERROR "PY_INSTALL_PATH is not set! Please define it with -DPY_INSTALL_PATH=<...>")
+    endif()
     find_package(Python3 COMPONENTS Interpreter Development)
     execute_process(
         COMMAND ${Python3_EXECUTABLE} -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
@@ -76,35 +105,10 @@ if(BUILD_LIB_ACS_INT)
     message(STATUS "Use Python: ${PYTHON_VERSION}")
     find_package(pybind11 CONFIG REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../.venv/lib/python${PYTHON_VERSION}/site-packages/pybind11/share/cmake/pybind11)
 
-    set(SOURCES_INT
-        src/interface_xbar.cpp
-        src/helper/config.cpp
-        src/helper/histogram.cpp
-        src/mapping/mapper.cpp
-        src/mapping/int_mapper/int_i.cpp
-        src/mapping/int_mapper/int_ii.cpp
-        src/mapping/int_mapper/int_iii.cpp
-        src/mapping/int_mapper/int_iv.cpp
-        src/mapping/int_mapper/int_v.cpp
-        src/mapping/bnn_mapper/bnn_i.cpp
-        src/mapping/bnn_mapper/bnn_ii.cpp
-        src/mapping/bnn_mapper/bnn_iii.cpp
-        src/mapping/bnn_mapper/bnn_iv.cpp
-        src/mapping/bnn_mapper/bnn_v.cpp
-        src/mapping/bnn_mapper/bnn_vi.cpp
-        src/mapping/tnn_mapper/tnn_i.cpp
-        src/mapping/tnn_mapper/tnn_ii.cpp
-        src/mapping/tnn_mapper/tnn_iii.cpp
-        src/mapping/tnn_mapper/tnn_iv.cpp
-        src/mapping/tnn_mapper/tnn_v.cpp
-        src/xbar/crossbar.cpp
-        src/xbar/read_disturb.cpp
-        src/xbar/parasitics.cpp
-        src/xbar/adc.cpp
-    )
+    set(SOURCES_INT src/interface_xbar.cpp)
 
     # Build pybind module
-    pybind11_add_module(acs_int SHARED ${SOURCES_INT})
+    pybind11_add_module(acs_int SHARED ${SOURCES_SHARED} ${SOURCES_INT})
     include_directories(inc extern/json/include)
     target_link_libraries(acs_int PRIVATE nlohmann_json::nlohmann_json pybind11::module)
 
@@ -123,6 +127,33 @@ if(BUILD_LIB_ACS_INT)
     install(TARGETS acs_int DESTINATION ${PY_INSTALL_PATH})
 endif()
 
+### Build cpp library ###
+if(BUILD_LIB_ACS_CPP)
+
+    message(STATUS "Build LIB_ACS_CPP.")
+
+    add_library(acs_cpp SHARED ${SOURCES_SHARED})
+    # Link json library
+    include_directories(inc extern/json/include)
+    target_link_libraries(acs_cpp PRIVATE nlohmann_json::nlohmann_json)
+
+    # Build with test coverage
+    if (COVERAGE)
+        target_compile_options(acs_cpp PRIVATE -fprofile-arcs -ftest-coverage)
+        target_link_libraries(acs_cpp PRIVATE gcov)
+    endif()
+
+    # Link with oneTBB (Thread Building Blocks)
+    find_package(TBB REQUIRED)
+    message(STATUS "Found TBB: (found version \"${TBB_VERSION}\"), linking acs_cpp against TBB (Parallel STL backend).")
+    target_link_libraries(acs_cpp PRIVATE TBB::tbb)
+
+    set_target_properties(acs_cpp PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    # Install into standard directories -> results in lib/ for library and include/ for header
+    install(TARGETS acs_cpp LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(DIRECTORY inc/ extern/json/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+endif()
 
 if(LIB_TESTS)
     message(STATUS "Enabling cpp tests.")

--- a/scripts/build_acs.sh
+++ b/scripts/build_acs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+
+# Dynamically locate the project root directory
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+PROJECT_ROOT=$(dirname "$SCRIPT_DIR")
+
+# Dynamically detect python version inside the .venv
+PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+
+# Can be found in .venv/lib/
+export PY_PACKAGE_DIR="${PROJECT_ROOT}/.venv/lib/python${PYTHON_VERSION}"
+
+mkdir -p "${PROJECT_ROOT}/build/debug/build"
+cd "${PROJECT_ROOT}/build/debug/build"
+
+# Build the project
+cmake \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DPY_INSTALL_PATH=${PY_PACKAGE_DIR}/site-packages \
+    -DCMAKE_PREFIX_PATH=${PY_PACKAGE_DIR}/pybind11/share/cmake/pybind11 \
+    -DCMAKE_INSTALL_PREFIX=../ \
+    -DLIB_TESTS=ON \
+    -DCOVERAGE=ON \
+    -DBUILD_LIB_CB_EMU=ON \
+    -DBUILD_LIB_ACS_INT=ON \
+    -DBUILD_LIB_ACS_CPP=ON \
+    -DDEBUG_MODE=OFF \
+    ../../../cpp
+
+make -j "$(nproc)"
+make install


### PR DESCRIPTION
I have added a new build target that creates a shared library (acs_cpp) which does not contain any of the pybind11 stuff but does install all headers of the project into the include directory. 
All in all the goal is to be able to link the (now pure cpp) shared library and include any header out of the project to be able to define our own crossbar and use all interfaces that come with it.

- added new option for building the cpp library and installing it with all headers
- added new devcontainer which should be able to build project out of the box
- added new build script, decreasing the number of actions needed to build the project
- added new build target to the ci

